### PR TITLE
refactor: Rename SelectForUpdate methods to Lock methods in ORM templates

### DIFF
--- a/internal/lang/go/generator/templates/package/each_file.go.tmpl
+++ b/internal/lang/go/generator/templates/package/each_file.go.tmpl
@@ -87,11 +87,11 @@ func (s *_ORM) Get{{ $table.StructName }}ByPK(ctx context.Context, queryerContex
 	return {{ $table.StructName | lowerFirst }}, nil
 }
 {{ if or (ne $.Dialect "sqlite3") }}
-const SelectForUpdate{{ $table.StructName }}ByPKQuery = `SELECT {{ range $i, $column := $table.Columns }}{{ if $i }}, {{ end }}{{ $column.ColumnName }}{{- end }} FROM {{ $table.TableName }} WHERE {{ placeholderInWhere $table.PrimaryKeys "AND" 1 }} FOR UPDATE`
+const Lock{{ $table.StructName }}ByPKQuery = `SELECT {{ range $i, $column := $table.Columns }}{{ if $i }}, {{ end }}{{ $column.ColumnName }}{{- end }} FROM {{ $table.TableName }} WHERE {{ placeholderInWhere $table.PrimaryKeys "AND" 1 }} FOR UPDATE`
 
-func (s *_ORM) SelectForUpdate{{ $table.StructName }}ByPK(ctx context.Context, queryerContext {{ $ormoptPackageImportPath }}.QueryerContext, {{ range $i, $pk := $table.PrimaryKeys }}{{ if $i }}, {{ end }}{{ $pk.ColumnName }} {{ $pk.FieldType }}{{ end }}) (*{{ $packageImportPath }}.{{ $table.StructName }}, error) {
-	{{ $ormoptPackageImportPath }}.LoggerFromContext(ctx).Debug(SelectForUpdate{{ $table.StructName }}ByPKQuery)
-	row := queryerContext.QueryRowContext(ctx, SelectForUpdate{{ $table.StructName }}ByPKQuery, {{ range $i, $pk := $table.PrimaryKeys }}{{ if $i }}, {{ end }}{{ $pk.ColumnName }}{{ end }})
+func (s *_ORM) Lock{{ $table.StructName }}ByPK(ctx context.Context, queryerContext {{ $ormoptPackageImportPath }}.QueryerContext, {{ range $i, $pk := $table.PrimaryKeys }}{{ if $i }}, {{ end }}{{ $pk.ColumnName }} {{ $pk.FieldType }}{{ end }}) (*{{ $packageImportPath }}.{{ $table.StructName }}, error) {
+	{{ $ormoptPackageImportPath }}.LoggerFromContext(ctx).Debug(Lock{{ $table.StructName }}ByPKQuery)
+	row := queryerContext.QueryRowContext(ctx, Lock{{ $table.StructName }}ByPKQuery, {{ range $i, $pk := $table.PrimaryKeys }}{{ if $i }}, {{ end }}{{ $pk.ColumnName }}{{ end }})
 	{{ $table.StructName | lowerFirst }} := new({{ $packageImportPath }}.{{ $table.StructName }})
 	err := row.Scan({{ range $i, $v := $table.Columns }}{{ if $i }}, {{ end }}&{{ $table.StructName | lowerFirst }}.{{ $v.FieldName }}{{- end }})
 	if err != nil {
@@ -115,15 +115,15 @@ func (s *_ORM) Get{{ $table.StructName }}By{{ $hasOneTagsKey }}(ctx context.Cont
 	return {{ $table.StructName | lowerFirst }}, nil
 }
 {{ if or (ne $.Dialect "sqlite3") }}
-const SelectForUpdate{{ $table.StructName }}By{{ $hasOneTagsKey }}Query = `SELECT {{ range $i, $column := $table.Columns }}{{ if $i }}, {{ end }}{{ $column.ColumnName }}{{- end }} FROM {{ $table.TableName }} WHERE {{ placeholderInWhere $hasOneColumns "AND" 1 }} FOR UPDATE`
+const Lock{{ $table.StructName }}By{{ $hasOneTagsKey }}Query = `SELECT {{ range $i, $column := $table.Columns }}{{ if $i }}, {{ end }}{{ $column.ColumnName }}{{- end }} FROM {{ $table.TableName }} WHERE {{ placeholderInWhere $hasOneColumns "AND" 1 }} FOR UPDATE`
 
-func (s *_ORM) SelectForUpdate{{ $table.StructName }}By{{ $hasOneTagsKey }}(ctx context.Context, queryerContext {{ $ormoptPackageImportPath }}.QueryerContext, {{ range $i, $hasOneCol := $hasOneColumns }}{{ if $i }}, {{ end }}{{ $hasOneCol.ColumnName }} {{ $hasOneCol.FieldType }}{{ end }}, opts ...{{ $ormoptPackageImportPath }}.ResultOption) (*{{ $packageImportPath }}.{{ $table.StructName }}, error) {
+func (s *_ORM) Lock{{ $table.StructName }}By{{ $hasOneTagsKey }}(ctx context.Context, queryerContext {{ $ormoptPackageImportPath }}.QueryerContext, {{ range $i, $hasOneCol := $hasOneColumns }}{{ if $i }}, {{ end }}{{ $hasOneCol.ColumnName }} {{ $hasOneCol.FieldType }}{{ end }}, opts ...{{ $ormoptPackageImportPath }}.ResultOption) (*{{ $packageImportPath }}.{{ $table.StructName }}, error) {
 	config := new({{ $ormoptPackageImportPath }}.QueryConfig)
 	{{ $ormoptPackageImportPath }}.WithPlaceholderGenerator(DefaultPlaceholderGenerator).ApplyResultOption(config)
 	for _, o := range opts {
 		o.ApplyResultOption(config)
 	}
-	query, args := config.ToSQL(SelectForUpdate{{ $table.StructName }}By{{ $hasOneTagsKey }}Query, {{ $currentIndex := len $hasOneColumns }}{{ add $currentIndex 1 }})
+	query, args := config.ToSQL(Lock{{ $table.StructName }}By{{ $hasOneTagsKey }}Query, {{ $currentIndex := len $hasOneColumns }}{{ add $currentIndex 1 }})
 	{{ $ormoptPackageImportPath }}.LoggerFromContext(ctx).Debug(query)
 	row := queryerContext.QueryRowContext(ctx, query, append([]interface{}{{print `{`}}{{ range $i, $hasOneCol := $hasOneColumns }}{{ if $i }}, {{ end }}{{ $hasOneCol.ColumnName }}{{ end }}{{print `}`}}, args...)...)
 	{{ $table.StructName | lowerFirst }} := new({{ $packageImportPath }}.{{ $table.StructName }})
@@ -169,15 +169,15 @@ func (s *_ORM) List{{ $table.StructName }}By{{ $hasManyTagsKey }}(ctx context.Co
 	return {{ $table.StructName | lowerFirst }}Slice, nil
 }
 {{ if or (ne $.Dialect "sqlite3") }}
-const SelectForUpdate{{ $table.StructName }}By{{ $hasManyTagsKey }}Query = `SELECT {{ range $i, $column := $table.Columns }}{{ if $i }}, {{ end }}{{ $column.ColumnName }}{{- end }} FROM {{ $table.TableName }} WHERE ({{ placeholderInWhere $hasManyColumns "AND" 1 }}) FOR UPDATE`
+const Lock{{ $table.StructName }}By{{ $hasManyTagsKey }}Query = `SELECT {{ range $i, $column := $table.Columns }}{{ if $i }}, {{ end }}{{ $column.ColumnName }}{{- end }} FROM {{ $table.TableName }} WHERE ({{ placeholderInWhere $hasManyColumns "AND" 1 }}) FOR UPDATE`
 
-func (s *_ORM) SelectForUpdate{{ $table.StructName }}By{{ $hasManyTagsKey }}(ctx context.Context, queryerContext {{ $ormoptPackageImportPath }}.QueryerContext, {{ range $i, $hasManyCol := $hasManyColumns }}{{ if $i }}, {{ end }}{{ $hasManyCol.ColumnName }} {{ $hasManyCol.FieldType }}{{ end }}, opts ...{{ $ormoptPackageImportPath }}.ResultOption) ({{ $packageImportPath }}.{{ $table.StructName }}{{ $.SliceTypeSuffix }}, error) {
+func (s *_ORM) Lock{{ $table.StructName }}By{{ $hasManyTagsKey }}(ctx context.Context, queryerContext {{ $ormoptPackageImportPath }}.QueryerContext, {{ range $i, $hasManyCol := $hasManyColumns }}{{ if $i }}, {{ end }}{{ $hasManyCol.ColumnName }} {{ $hasManyCol.FieldType }}{{ end }}, opts ...{{ $ormoptPackageImportPath }}.ResultOption) ({{ $packageImportPath }}.{{ $table.StructName }}{{ $.SliceTypeSuffix }}, error) {
 	config := new({{ $ormoptPackageImportPath }}.QueryConfig)
 	{{ $ormoptPackageImportPath }}.WithPlaceholderGenerator(DefaultPlaceholderGenerator).ApplyResultOption(config)
 	for _, o := range opts {
 		o.ApplyResultOption(config)
 	}
-	query, args := config.ToSQL(SelectForUpdate{{ $table.StructName }}By{{ $hasManyTagsKey }}Query, {{ $currentIndex := len $hasManyColumns }}{{ add $currentIndex 1 }})
+	query, args := config.ToSQL(Lock{{ $table.StructName }}By{{ $hasManyTagsKey }}Query, {{ $currentIndex := len $hasManyColumns }}{{ add $currentIndex 1 }})
 	{{ $ormoptPackageImportPath }}.LoggerFromContext(ctx).Debug(query)
 	rows, err := queryerContext.QueryContext(ctx, query, append([]interface{}{{print `{`}}{{ range $i, $hasManyCol := $hasManyColumns }}{{ if $i }}, {{ end }}{{ $hasManyCol.ColumnName }}{{ end }}{{print `}`}}, args...)...)
 	if err != nil {
@@ -234,15 +234,15 @@ func (s *_ORM) List{{ $table.StructName }}(ctx context.Context, queryerContext {
 	return {{ $table.StructName | lowerFirst }}Slice, nil
 }
 {{ if or (ne $.Dialect "sqlite3") }}
-const SelectForUpdate{{ $table.StructName }}Query = `SELECT {{ range $i, $column := $table.Columns }}{{ if $i }}, {{ end }}{{ $column.ColumnName }}{{- end }} FROM {{ $table.TableName }}`
+const Lock{{ $table.StructName }}Query = `SELECT {{ range $i, $column := $table.Columns }}{{ if $i }}, {{ end }}{{ $column.ColumnName }}{{- end }} FROM {{ $table.TableName }}`
 
-func (s *_ORM) SelectForUpdate{{ $table.StructName }}(ctx context.Context, queryerContext {{ $ormoptPackageImportPath }}.QueryerContext, opts ...{{ $ormoptPackageImportPath }}.QueryOption) ({{ $packageImportPath }}.{{ $table.StructName }}{{ $.SliceTypeSuffix }}, error) {
+func (s *_ORM) Lock{{ $table.StructName }}(ctx context.Context, queryerContext {{ $ormoptPackageImportPath }}.QueryerContext, opts ...{{ $ormoptPackageImportPath }}.QueryOption) ({{ $packageImportPath }}.{{ $table.StructName }}{{ $.SliceTypeSuffix }}, error) {
 	config := new({{ $ormoptPackageImportPath }}.QueryConfig)
 	{{ $ormoptPackageImportPath }}.WithPlaceholderGenerator(DefaultPlaceholderGenerator).ApplyResultOption(config)
 	for _, o := range opts {
 		o.ApplyQueryOption(config)
 	}
-	query, args := config.ToSQL(SelectForUpdate{{ $table.StructName }}Query, 1)
+	query, args := config.ToSQL(Lock{{ $table.StructName }}Query, 1)
 	{{ $ormoptPackageImportPath }}.LoggerFromContext(ctx).Debug(query)
 	rows, err := queryerContext.QueryContext(ctx, query, args...)
 	if err != nil {


### PR DESCRIPTION
<!-- markdownlint-disable MD004 MD041 -->

## Ticket / Issue Number

> **Note**
> *Please fill in the ticket or issue number.*
> > Example:
> >
> > #1

## What's changed

> **Note**
> *Please explain what changes this pull request will make.*
> > Example:
> >
> > - Added functionality to perform 'bar' on 'foo'.

## Check List

- [x] Assign labels
- [x] Assign reviewers
- [x] Assign assignees
- [x] Add appropriate test cases

## Remark

> **Note**
> *Please provide additional remarks if necessary.*

<!-- markdownlint-enable MD004 MD041 -->
