### PR TITLE
fix: Skip finding package import path when generating table file only

### DIFF
--- a/internal/lang/go/source/work_dir.go
+++ b/internal/lang/go/source/work_dir.go
@@ -36,10 +36,10 @@ func newParseWalkDir(ctx context.Context, sourcePath string, fileExt string, pac
 		}
 
 		cfg := contexts.GenerateConfig(ctx)
-		packageImportPath := cfg.GoORMStructPackageImportPath
-		if packageImportPath == "" {
+		ormStructPackageImportPath := cfg.GoORMStructPackageImportPath
+		if ormStructPackageImportPath == "" && !cfg.GoTableFileOnly /* if table file only, don't need to find package import path */ {
 			if err := tracez.StartFuncWithSpanNameSuffix(ctx, "buildz.FindPackageImportPath", func(_ context.Context) (err error) {
-				packageImportPath, err = buildz.FindPackageImportPath(sourcePath)
+				ormStructPackageImportPath, err = buildz.FindPackageImportPath(sourcePath)
 				//nolint:wrapcheck
 				return err
 			}); err != nil {
@@ -59,7 +59,7 @@ func newParseWalkDir(ctx context.Context, sourcePath string, fileExt string, pac
 		packageSources.AddPackageSource(&PackageSource{
 			PackageName:        fileSource.PackageName,
 			DirPath:            filepath.Dir(fileSource.FilePath),
-			PackageImportPath:  filepath.Join(packageImportPath, filepath.Dir(fileSource.SourceRelativePath)),
+			PackageImportPath:  filepath.Join(ormStructPackageImportPath, filepath.Dir(fileSource.SourceRelativePath)),
 			SourceRelativePath: filepath.Dir(fileSource.SourceRelativePath),
 			FileSources:        FileSourceSlice{fileSource},
 		})

--- a/internal/lang/go/source/work_dir.go
+++ b/internal/lang/go/source/work_dir.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hakadoriya/ormgen/pkg/apperr"
 )
 
+//nolint:cyclop
 func newParseWalkDir(ctx context.Context, sourcePath string, fileExt string, packageSources *PackageSourceSlice) func(path string, d fs.DirEntry, err error) error {
 	walkDir := func(filePath string, d fs.DirEntry, err error) error {
 		ctx, span := tracez.StartWithSpanNameSuffix(ctx, "walkDir")


### PR DESCRIPTION
<!-- markdownlint-disable MD004 MD041 -->

## Ticket / Issue Number

> **Note**
> *Please fill in the ticket or issue number.*
> > Example:
> >
> > #1

## What's changed

> **Note**
> *Please explain what changes this pull request will make.*
> > Example:
> >
> > - Added functionality to perform 'bar' on 'foo'.

## Check List

- [x] Assign labels
- [x] Assign reviewers
- [x] Assign assignees
- [x] Add appropriate test cases

## Remark

> **Note**
> *Please provide additional remarks if necessary.*

<!-- markdownlint-enable MD004 MD041 -->
